### PR TITLE
Add CostReport and viewer page

### DIFF
--- a/DxBlazorReport/Pages/ReportViewer_CostReport.razor
+++ b/DxBlazorReport/Pages/ReportViewer_CostReport.razor
@@ -1,0 +1,19 @@
+@page "/costreport/"
+
+@using DevExpress.Blazor.Reporting
+@using DevExpress.XtraReports.UI
+@using DevExpress.Blazor.Reporting.Models
+@using DevExpress.Blazor
+@using DxBlazorReport.PredefinedReports
+@using Models
+
+<link href="_content/DevExpress.Blazor.Themes/blazing-berry.bs5.css" rel="stylesheet" />
+<link href="_content/DevExpress.Blazor.Reporting.Viewer/css/dx-blazor-reporting-components.bs5.css" rel="stylesheet" />
+
+<DxReportViewer @ref="reportViewer" Report="Report" RootCssClasses="w-100 h-100" />
+
+@code {
+    DxReportViewer reportViewer;
+    XtraReport Report = new CostReport();
+
+}

--- a/DxBlazorReport/PredefinedReports/CostReport.Designer.cs
+++ b/DxBlazorReport/PredefinedReports/CostReport.Designer.cs
@@ -1,0 +1,36 @@
+namespace DxBlazorReport.PredefinedReports
+{
+    partial class CostReport
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+        }
+
+        #endregion
+    }
+}

--- a/DxBlazorReport/PredefinedReports/CostReport.cs
+++ b/DxBlazorReport/PredefinedReports/CostReport.cs
@@ -1,0 +1,12 @@
+using DevExpress.XtraReports.UI;
+
+namespace DxBlazorReport.PredefinedReports
+{
+    public partial class CostReport : XtraReport
+    {
+        public CostReport()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DxBlazorReport/PredefinedReports/CostReport.resx
+++ b/DxBlazorReport/PredefinedReports/CostReport.resx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+  -->
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/DxBlazorReport/PredefinedReports/ReportsFactory.cs
+++ b/DxBlazorReport/PredefinedReports/ReportsFactory.cs
@@ -8,7 +8,8 @@ namespace DxBlazorReport.PredefinedReports
         {
             ["DepartmentQueueCountRecordViewReport"] = () => new DepartmentQueueCountRecordViewReport(),
             ["DepartmentQueueProcessesViewReport"] = () => new DepartmentQueueProcessesViewReport(),
-            ["EmployeeReport"] = () => new EmployeeReport()
+            ["EmployeeReport"] = () => new EmployeeReport(),
+            ["CostReport"] = () => new CostReport()
         };
     }
 }

--- a/DxBlazorReport/Shared/NavMenu.razor
+++ b/DxBlazorReport/Shared/NavMenu.razor
@@ -79,6 +79,11 @@
                 <span class="oi oi-list-rich" aria-hidden="true"></span>Workcenter Report
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="costreport">
+                <span class="oi oi-list-rich" aria-hidden="true"></span>Cost Report
+            </NavLink>
+        </li>
         @* <li class="nav-item px-3">
             <NavLink class="nav-link" href="workcenterreportext">
                 <span class="oi oi-list-rich" aria-hidden="true"></span>Workcenter (test) Report


### PR DESCRIPTION
## Summary
- add CostReport skeleton report with designer and resx files
- register new report in ReportsFactory
- create report viewer page for CostReport
- add Cost Report link to navigation menu

## Testing
- `dotnet build DxBlazorReport/DxBlazorReport.csproj -nologo` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_683db70365fc832982013cae0f8eaffd